### PR TITLE
Don't use the --agent option when executing keychain.

### DIFF
--- a/keychain-environment.el
+++ b/keychain-environment.el
@@ -58,17 +58,16 @@ Set the environment variables `SSH_AUTH_SOCK', `SSH_AGENT_PID'
 and `GPG_AGENT' in Emacs' `process-environment' according to
 information retrieved from files created by the keychain script."
   (interactive)
-  (let* ((ssh (shell-command-to-string "keychain -q --noask --agents ssh --eval"))
-         (gpg (shell-command-to-string "keychain -q --noask --agents gpg --eval")))
-    (list (and ssh
-               (string-match "SSH_AUTH_SOCK[=\s]\"?\\([^\s;\n\"]*\\)" ssh)
-               (setenv       "SSH_AUTH_SOCK" (match-string 1 ssh)))
-          (and ssh
-               (string-match "SSH_AGENT_PID[=\s]\\([0-9]*\\)?" ssh)
-               (setenv       "SSH_AGENT_PID" (match-string 1 ssh)))
-          (and gpg
-               (string-match "GPG_AGENT_INFO[=\s]\\([^\s;\n]*\\)" gpg)
-               (setenv       "GPG_AGENT_INFO" (match-string 1 gpg))))))
+  (let ((env (shell-command-to-string "keychain -q --noask --eval")))
+    (list (and env
+               (string-match "SSH_AUTH_SOCK[=\s]\"?\\([^\s;\n\"]*\\)" env)
+               (setenv       "SSH_AUTH_SOCK" (match-string 1 env)))
+          (and env
+               (string-match "SSH_AGENT_PID[=\s]\"?\\([0-9]*\\)?" env)
+               (setenv       "SSH_AGENT_PID" (match-string 1 env)))
+          (and env
+               (string-match "GPG_AGENT_INFO[=\s]\"?\\([^\s;\n\"]*\\)" env)
+               (setenv       "GPG_AGENT_INFO" (match-string 1 env))))))
 
 ;;; _
 (provide 'keychain-environment)


### PR DESCRIPTION
Since the release of keychain 3.0, the --agent option that was previously deprecated, has been removed.

As a consequence, the invocation of keychain in the elisp script causes an error and fails to parse the environment variables.

This commit invokes keychain only once without the --agents option and executes the three regular expressions on the output of that single command.

Tested on Arch Linux with keychain 3.0.1.